### PR TITLE
Add rate limiting module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # copilot-test
+
+## Rate Limiting Module
+
+This module provides a simple way to implement rate limiting for your applications. It uses a sliding window log algorithm to efficiently manage request rates over time.
+
+### How to Use
+
+To use the `RateLimiter` class, you need to initialize it with the maximum number of requests allowed within a given window size in seconds. Here is a basic example:
+
+```python
+from rate_limiter import RateLimiter
+
+# Initialize the rate limiter to allow 100 requests per minute
+rate_limiter = RateLimiter(max_requests=100, window_size=60)
+
+# Check if a request is allowed
+if rate_limiter.allow_request():
+    print("Request allowed")
+else:
+    print("Request denied")
+```
+
+### Dependencies
+
+This module requires Python 3.6 or later. No external libraries are needed.

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,0 +1,30 @@
+import time
+
+class RateLimiter:
+    def __init__(self, max_requests, window_size):
+        """
+        Initializes a RateLimiter object with a maximum number of requests
+        allowed within a given window size in seconds.
+        
+        :param max_requests: Maximum number of requests allowed
+        :param window_size: Window size in seconds
+        """
+        self.max_requests = max_requests
+        self.window_size = window_size
+        self.request_timestamps = []
+
+    def allow_request(self):
+        """
+        Determines if a new request is allowed under the current rate limit.
+        
+        :return: True if the request is allowed, False otherwise
+        """
+        current_time = time.time()
+        # Clean up old timestamps that are outside the rate limit window
+        self.request_timestamps = [timestamp for timestamp in self.request_timestamps if current_time - timestamp < self.window_size]
+        
+        if len(self.request_timestamps) < self.max_requests:
+            self.request_timestamps.append(current_time)
+            return True
+        else:
+            return False


### PR DESCRIPTION
Adds a new rate limiting module and updates the README.md to document its usage.

- **New Module**: Implements the `RateLimiter` class in `rate_limiter.py`, which allows initializing with a maximum number of requests and a window size in seconds. It includes a method `allow_request` to check if a new request is within the rate limits, using a sliding window log algorithm.
- **README.md Update**: Enhances the documentation to include a new section on the Rate Limiting Module, providing a brief description, a simple usage example, and mentioning the Python version dependency without the need for external libraries.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deep-diver/copilot-test?shareId=1f6be256-74e1-4a88-a39b-ea1c574ad690).