### PR TITLE
Enhance rate limiter to consider number of workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This module provides a simple way to implement rate limiting for your applicatio
 
 ### How to Use
 
-To use the `RateLimiter` class, you need to initialize it with the maximum number of requests allowed within a given window size in seconds. Here is a basic example:
+To use the `RateLimiter` class, you need to initialize it with the maximum number of requests allowed within a given window size in seconds, and the number of concurrent workers. Here is a basic example:
 
 ```python
 from rate_limiter import RateLimiter
 
-# Initialize the rate limiter to allow 100 requests per minute
-rate_limiter = RateLimiter(max_requests=100, window_size=60)
+# Initialize the rate limiter to allow 100 requests per minute for 5 workers
+rate_limiter = RateLimiter(max_requests=100, window_size=60, worker_count=5)
 
 # Check if a request is allowed
 if rate_limiter.allow_request():
@@ -20,6 +20,10 @@ if rate_limiter.allow_request():
 else:
     print("Request denied")
 ```
+
+### Understanding the Worker Count Parameter
+
+The `worker_count` parameter is crucial for applications that operate with multiple concurrent workers or threads. It allows the `RateLimiter` to adjust the rate limiting logic proportionally, ensuring that the overall rate limit is maintained across all workers. This means that the effective rate limit per worker is the total `max_requests` divided by the `worker_count`. This adjustment ensures fair access and prevents any single worker from monopolizing the request quota.
 
 ### Dependencies
 

--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,21 +1,25 @@
 import time
 
 class RateLimiter:
-    def __init__(self, max_requests, window_size):
+    def __init__(self, max_requests, window_size, worker_count=1):
         """
         Initializes a RateLimiter object with a maximum number of requests
-        allowed within a given window size in seconds.
+        allowed within a given window size in seconds, considering the number
+        of concurrent workers.
         
         :param max_requests: Maximum number of requests allowed
         :param window_size: Window size in seconds
+        :param worker_count: Number of concurrent workers (default is 1)
         """
         self.max_requests = max_requests
         self.window_size = window_size
+        self.worker_count = worker_count
         self.request_timestamps = []
 
     def allow_request(self):
         """
-        Determines if a new request is allowed under the current rate limit.
+        Determines if a new request is allowed under the current rate limit,
+        adjusting the rate limiting logic based on the worker count.
         
         :return: True if the request is allowed, False otherwise
         """
@@ -23,7 +27,9 @@ class RateLimiter:
         # Clean up old timestamps that are outside the rate limit window
         self.request_timestamps = [timestamp for timestamp in self.request_timestamps if current_time - timestamp < self.window_size]
         
-        if len(self.request_timestamps) < self.max_requests:
+        adjusted_max_requests = self.max_requests / self.worker_count
+        
+        if len(self.request_timestamps) < adjusted_max_requests:
             self.request_timestamps.append(current_time)
             return True
         else:


### PR DESCRIPTION
Enhances the `RateLimiter` class in `rate_limiter.py` to support rate limiting based on the number of concurrent workers and updates the documentation accordingly.

- **Code Modification**: 
  - Adds a `worker_count` parameter to the `RateLimiter` class constructor, allowing the rate limiter to adjust its behavior based on the number of concurrent workers.
  - Modifies the `allow_request` method to divide the `max_requests` by `worker_count` before comparing it with the length of `self.request_timestamps`, effectively adjusting the rate limiting logic based on the number of workers.
  - Updates the docstrings of the `RateLimiter` class and the `allow_request` method to include information about the new `worker_count` parameter and its impact on rate limiting logic.

- **Documentation Update**:
  - Updates the example usage in `README.md` to demonstrate how to initialize the `RateLimiter` with the `worker_count` parameter.
  - Adds a new section explaining the purpose of the `worker_count` parameter and how it affects the rate limiting logic, ensuring users understand the importance of this parameter in scenarios with multiple concurrent workers.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deep-diver/copilot-test?shareId=ee3d511a-bbce-4d2a-b20f-b3d14d7ee041).